### PR TITLE
Add some option (if, event and lazy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # plugpac
+
+本家に、 `if` と `lazy` 追加してます。
+詳細は [yukimemi's blog - Use plugpac.vim](https://yukimemi.netlify.com/use-plugpac-vim/) 参照。
+
 ## Overview
-Plugpac is a thin wrapper over [minpac][1], leveraging the power of Vim8(and Neovim) native package manager and jobs feature. It's even faster than [vim-plug][2].  
+Plugpac is a thin wrapper over [minpac][1], leveraging the power of Vim8(and Neovim) native package manager and jobs feature. It's even faster than [vim-plug][2].
 
 In my case, it takes 18ms to start up with 53 out 87 plugins loaded(the rest will be load on demand). While vim-plug takes 35ms.
 
@@ -37,7 +41,7 @@ Pack 'tpope/vim-sensible', { 'rev': 'v1.2' }
 
 call plugpac#end()
 ```
-Reload .vimrc and `:PackInstall` to install plugins.  
+Reload .vimrc and `:PackInstall` to install plugins.
 `Pack` command just handles `for` and `on` options(i.e. lazy load, implies `'type': 'opt'`). Other options are passed to `minpac#add` directly. See [minpac][1] for more imformation.
 
 ## Commands
@@ -48,7 +52,7 @@ Reload .vimrc and `:PackInstall` to install plugins.
 - PackDisable: Move a plugin to `minpac/opt`.(`minpac#update` would move plugin back to `minpac/start`, unless the plugin is explicitly optional. Useful for disabling a plugin temporarily)
 
 ## Credit
-K.Takata(as the author of [minpac][1])  
+K.Takata(as the author of [minpac][1])
 Junegunn Choi(as the author of [vim-plug][2])
 
 [1]: https://github.com/k-takata/minpac

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # plugpac
 
-本家に、 `if` と `lazy` 追加してます。
-詳細は [yukimemi's blog - Use plugpac.vim](https://yukimemi.netlify.com/use-plugpac-vim/) 参照。
-
 ## Overview
 Plugpac is a thin wrapper over [minpac][1], leveraging the power of Vim8(and Neovim) native package manager and jobs feature. It's even faster than [vim-plug][2].
 
@@ -22,13 +19,17 @@ curl -fLo ~/.vim/autoload/plugpac.vim --create-dirs \
 call plugpac#begin()
 
 " minpac
-Pack 'k-takata/minpac', {'type': 'opt'}
+Pack 'k-takata/minpac', { 'type': 'opt' }
 
 Pack 'junegunn/vim-easy-align'
 
 " On-demand loading
 Pack 'scrooloose/nerdtree', { 'on':  'NERDTreeToggle' }
 Pack 'tpope/vim-fireplace', { 'for': 'clojure' }
+Pack 'ntpeters/vim-better-whitespace', { 'event': 'CursorHold' }
+" String or List support
+Pack 'pangloss/vim-javascript', { 'for': ['javascript', 'javascript.jsx'] }
+Pack 'neoclide/coc.nvim', { 'event': ['InsertEnter', 'CursorMoved'] }
 
 " Using a non-master branch
 Pack 'rdnetto/YCM-Generator', { 'branch': 'stable' }
@@ -39,10 +40,19 @@ Pack 'Yggdroot/LeaderF', { 'do': {-> system('./install.sh')} }
 " Sepcify commit ID, branch name or tag name to be checked out.
 Pack 'tpope/vim-sensible', { 'rev': 'v1.2' }
 
+" Only valid if conditions are met
+Pack 'nvim-treesitter/nvim-treesitter', { 'if': has('nvim') }
+
+" After VimEnter, the timer_start function packadd plugins
+Pack 'andymass/vim-matchup', { 'type': 'lazy' }
+
 call plugpac#end()
 ```
 Reload .vimrc and `:PackInstall` to install plugins.
-`Pack` command just handles `for` and `on` options(i.e. lazy load, implies `'type': 'opt'`). Other options are passed to `minpac#add` directly. See [minpac][1] for more imformation.
+`Pack` command just handles `for` , `on` , `event` and `if` options(i.e. lazy load, implies `'type': 'opt'`).
+If `'type': 'lazy'` is set, it will be asynchronously packadded by the timer_start function after the VimEnter event.
+
+Other options are passed to `minpac#add` directly. See [minpac][1] for more imformation.
 
 ## Commands
 - PackInstall: Install newly added plugins.(`minpac#update()`)
@@ -50,6 +60,30 @@ Reload .vimrc and `:PackInstall` to install plugins.
 - PackClean: Uninstall unused plugins.(`minpac#clean()`)
 - PackStatus: See plugins status.(`minpac#status()`)
 - PackDisable: Move a plugin to `minpac/opt`.(`minpac#update` would move plugin back to `minpac/start`, unless the plugin is explicitly optional. Useful for disabling a plugin temporarily)
+
+## Plugin config path
+
+If you set `g:plugpac_cfg_path`, the plugin settings will be automatically sourced.
+
+```vim
+let g:plugpac_cfg_path = '~/.vim/rc'
+
+call plugpac#begin()
+
+" source ~/.vim/rc/nerdtree.vim if exists
+Pack 'scrooloose/nerdtree', { 'on':  'NERDTreeToggle' }
+" source ~/.vim/rc/coc.nvim if exists
+Pack 'neoclide/coc.nvim', { 'event': ['InsertEnter', 'CursorMoved'] }
+" source ~/.vim/rc/LeaderF.vim if exists
+Pack 'Yggdroot/LeaderF', { 'do': {-> system('./install.sh')} }
+" source ~/.vim/rc/vim-matchup.vim if exists
+Pack 'andymass/vim-matchup', { 'type': 'lazy' }
+
+" It will be asynchronously source by the timer_start function after the VimEnter event.
+Pack 'haya14busa/vim-edgemotion', { 'type': 'lazyall' }
+
+call plugpac#end()
+```
 
 ## Credit
 K.Takata(as the author of [minpac][1])

--- a/plugpac.vim
+++ b/plugpac.vim
@@ -11,7 +11,7 @@ let s:TYPE = {
       \ }
 
 function! plugpac#begin()
-  let s:lazy = { 'ft': {}, 'map': {}, 'cmd': {}, 'if': {} }
+  let s:lazy = { 'ft': {}, 'map': {}, 'cmd': {} }
   let s:repos = {}
   let s:repos_lazy = []
 
@@ -212,9 +212,10 @@ let s:idx = 0
 function! PackAddHandler(timer)
   execute 'packadd ' . s:repos_lazy[s:idx]
   let s:idx += 1
-  autocmd! PlugPacLazy
   if s:idx == len(s:repos_lazy)
     echom "lazy load done !"
+    autocmd! PlugPacLazy
+    augroup! PlugPacLazy
   endif
 endfunction
 

--- a/plugpac.vim
+++ b/plugpac.vim
@@ -11,10 +11,8 @@ let s:TYPE = {
       \ }
 
 
-
 function! plugpac#begin()
   let s:plugpac_cfg_path = get(g:, 'plugpac_cfg_path', '')
-  let s:plugpac_lazy_source = get(g:, 'plugpac_lazy_source', 0)
 
   let s:lazy = { 'ft': {}, 'map': {}, 'cmd': {} }
   let s:repos = {}
@@ -72,7 +70,7 @@ function! plugpac#add(repo, ...) abort
   endif
 
   " lazy plugins
-  if l:type == 'lazy'
+  if l:type == 'lazy' || l:type == 'lazyall'
     let l:opts['type'] = 'opt'
     let l:lazy[l:name] = ''
   endif
@@ -112,7 +110,7 @@ function! plugpac#add(repo, ...) abort
       let l:path = l:plug_cfg_vim
     endif
     if l:path != ''
-      if l:type == 'lazy' && s:plugpac_lazy_source
+      if l:type == 'lazyall'
         let l:lazy[l:name] = l:path
       else
         execute printf('source %s', l:path)
@@ -120,7 +118,7 @@ function! plugpac#add(repo, ...) abort
     endif
   endif
 
-  if l:type == 'lazy'
+  if l:type == 'lazy' || l:type == 'lazyall'
     call add(s:repos_lazy, l:lazy)
   endif
 

--- a/plugpac.vim
+++ b/plugpac.vim
@@ -10,7 +10,12 @@ let s:TYPE = {
       \   'funcref': type(function('call'))
       \ }
 
+
+
 function! plugpac#begin()
+  let s:plugpac_cfg_path = get(g:, 'plugpac_cfg_path', '')
+  let s:plugpac_lazy_source = get(g:, 'plugpac_lazy_source', 0)
+
   let s:lazy = { 'ft': {}, 'map': {}, 'cmd': {} }
   let s:repos = {}
   let s:repos_lazy = []
@@ -97,10 +102,9 @@ function! plugpac#add(repo, ...) abort
   endif
 
   " Load plugi config if exist.
-  let l:plugpac_cfg_path = get(g:, 'plugpac_cfg_path', '')
-  if l:plugpac_cfg_path != ''
-    let l:plug_cfg = expand(l:plugpac_cfg_path . '/' . l:name)
-    let l:plug_cfg_vim = expand(l:plugpac_cfg_path . '/' . l:name . '.vim')
+  if s:plugpac_cfg_path != ''
+    let l:plug_cfg = expand(s:plugpac_cfg_path . '/' . l:name)
+    let l:plug_cfg_vim = expand(s:plugpac_cfg_path . '/' . l:name . '.vim')
     let l:path = ''
     if filereadable(l:plug_cfg)
       let l:path = l:plug_cfg
@@ -108,7 +112,7 @@ function! plugpac#add(repo, ...) abort
       let l:path = l:plug_cfg_vim
     endif
     if l:path != ''
-      if l:type == 'lazy'
+      if l:type == 'lazy' && s:plugpac_lazy_source
         let l:lazy[l:name] = l:path
       else
         execute printf('source %s', l:path)

--- a/plugpac.vim
+++ b/plugpac.vim
@@ -14,7 +14,7 @@ let s:TYPE = {
 function! plugpac#begin()
   let s:plugpac_cfg_path = get(g:, 'plugpac_cfg_path', '')
 
-  let s:lazy = { 'ft': {}, 'map': {}, 'cmd': {} }
+  let s:lazy = { 'ft': {}, 'map': {}, 'cmd': {}, 'event': {} }
   let s:repos = {}
   let s:repos_lazy = []
 
@@ -55,6 +55,12 @@ function! plugpac#end()
     augroup END
   endfor
 
+  for [l:name, l:events] in items(s:lazy.event)
+    augroup PlugPac
+      execute printf('autocmd %s * ++once packadd %s', l:events, l:name)
+    augroup END
+  endfor
+
 endfunction
 
 " https://github.com/k-takata/minpac/issues/28
@@ -81,6 +87,12 @@ function! plugpac#add(repo, ...) abort
     let s:lazy.ft[l:name] = l:ft
   endif
 
+  if has_key(l:opts, 'event')
+    let l:opts['type'] = 'opt'
+    let l:event = type(l:opts.event) == s:TYPE.list ? join(l:opts.event, ',') : l:opts.event
+    let s:lazy.event[l:name] = l:event
+  endif
+
   if has_key(l:opts, 'on')
     let l:opts['type'] = 'opt'
     for l:cmd in s:to_a(l:opts.on)
@@ -99,7 +111,7 @@ function! plugpac#add(repo, ...) abort
     endfor
   endif
 
-  " Load plugi config if exist.
+  " Load plugin config if exist.
   if s:plugpac_cfg_path != ''
     let l:plug_cfg = expand(s:plugpac_cfg_path . '/' . l:name)
     let l:plug_cfg_vim = expand(s:plugpac_cfg_path . '/' . l:name . '.vim')

--- a/plugpac.vim
+++ b/plugpac.vim
@@ -187,7 +187,7 @@ function! s:setup_command()
   command! -bar -nargs=+ Pack call plugpac#add(<args>)
 
   command! -bar PackInstall call s:init_minpac() | call minpac#update(keys(filter(copy(g:minpac#pluglist), {-> !isdirectory(v:val.dir . '/.git')})))
-  command! -bar PackUpdate  call s:init_minpac() | call minpac#update('', {'do': 'call minpac#status()'})
+  command! -bar PackUpdate  call s:init_minpac() | call minpac#update()
   command! -bar PackClean   call s:init_minpac() | call minpac#clean()
   command! -bar PackStatus  call s:init_minpac() | call minpac#status()
   command! -bar -nargs=1 -complete=customlist,s:plugin_dir_complete PackDisable call s:disable_plugin(<q-args>)

--- a/plugpac.vim
+++ b/plugpac.vim
@@ -163,7 +163,7 @@ endfunction
 function! s:setup_command()
   command! -bar -nargs=+ Pack call plugpac#add(<args>)
 
-  command! -bar PackInstall call s:init_minpac() | call minpac#update(keys(filter(copy(minpac#pluglist), {-> !isdirectory(v:val.dir . '/.git')})))
+  command! -bar PackInstall call s:init_minpac() | call minpac#update(keys(filter(copy(g:minpac#pluglist), {-> !isdirectory(v:val.dir . '/.git')})))
   command! -bar PackUpdate  call s:init_minpac() | call minpac#update('', {'do': 'call minpac#status()'})
   command! -bar PackClean   call s:init_minpac() | call minpac#clean()
   command! -bar PackStatus  call s:init_minpac() | call minpac#status()

--- a/plugpac.vim
+++ b/plugpac.vim
@@ -236,10 +236,10 @@ function! PackAddHandler(timer)
   let l:plug = items(s:repos_lazy[s:idx])[0]
   let l:name = l:plug[0]
   let l:path = l:plug[1]
+  execute 'packadd ' . l:name
   if filereadable(l:path)
     execute printf('source %s', l:path)
   endif
-  execute 'packadd ' . l:name
   let s:idx += 1
   if s:idx == len(s:repos_lazy)
     echom "lazy load done !"


### PR DESCRIPTION
Add some options.

- On-demand loading vim event

```vim
Pack 'ntpeters/vim-better-whitespace', { 'event': 'CursorHold' }
Pack 'neoclide/coc.nvim', { 'event': ['InsertEnter', 'CursorMoved'] }
```

- Only valid if conditions are met

```vim
Pack 'nvim-treesitter/nvim-treesitter', { 'if': has('nvim') }
```

- After VimEnter, the timer_start function packadd plugins

```vim
Pack 'andymass/vim-matchup', { 'type': 'lazy' }
```

- Add `g:plugpac_cfg_path` option.

```vim
let g:plugpac_cfg_path = '~/.vim/rc'
```
